### PR TITLE
Use primary screen to calculate visible positions

### DIFF
--- a/macos/Classes/ScreenRetrieverPlugin.swift
+++ b/macos/Classes/ScreenRetrieverPlugin.swift
@@ -10,12 +10,12 @@ extension NSScreen {
 extension NSRect {
     var topLeft: CGPoint {
         set {
-            let screenFrameRect = NSScreen.main!.frame
+            let screenFrameRect = NSScreen.screens[0].frame
             origin.x = newValue.x
             origin.y = screenFrameRect.height - newValue.y - size.height
         }
         get {
-            let screenFrameRect = NSScreen.main!.frame
+            let screenFrameRect = NSScreen.screens[0].frame
             return CGPoint(x: origin.x, y: screenFrameRect.height - origin.y - size.height)
         }
     }
@@ -88,7 +88,7 @@ public class ScreenRetrieverPlugin: NSObject, FlutterPlugin {
     }
     
     public func getPrimaryDisplay(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        let resultData: NSDictionary = _screenToDict(NSScreen.main!)
+        let resultData: NSDictionary = _screenToDict(NSScreen.screens[0])
         result(resultData)
     }
     


### PR DESCRIPTION
The `NSScreen.main!` doesn't refer to the primary screen which causes the `visiblePosition` isn't correct if we check it in the app which is running on the secondary screen. The results from getAllDisplays() method are different between screens, but they should be the same, no matter where the app is located(on the primary or secondary screen). Using `NSScreen.screens[0]` guarantees the results of getAllDisplays() method are always consistent as  `NSScreen.screens[0]` always refers to the primary screen.