### PR TITLE
avoid nullptr as the param of fl_value_new_string

### DIFF
--- a/linux/screen_retriever_plugin.cc
+++ b/linux/screen_retriever_plugin.cc
@@ -58,7 +58,7 @@ FlValue* monitor_to_flvalue(GdkMonitor* monitor) {
 
   auto value = fl_value_new_map();
   fl_value_set_string_take(value, "id", fl_value_new_float(0));
-  fl_value_set_string_take(value, "name", fl_value_new_string(name));
+  fl_value_set_string_take(value, "name", fl_value_new_string(name == nullptr ? "" : name));
   fl_value_set_string_take(value, "size", size);
   fl_value_set_string_take(value, "visibleSize", visible_size);
   fl_value_set_string_take(value, "visiblePosition", visible_position);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/4997#issuecomment-1657004447

If the param of `fl_value_new_string` is NULL, this function will not report error.
The function returns an error value, which causes crash.

https://github.com/flutter/engine/blob/70b5700b79f6da03ecfb61f6d9135ca3eef51628/shell/platform/linux/fl_value.cc#L642

