### PR TITLE
fix: null check in `ScreenRetriever._handleScreenEvent`

### DIFF
--- a/packages/screen_retriever/lib/src/screen_retriever.dart
+++ b/packages/screen_retriever/lib/src/screen_retriever.dart
@@ -12,7 +12,8 @@ class ScreenRetriever {
 
   /// Handle screen events from the platform side.
   void _handleScreenEvent(event) {
-    String type = event['type'] as String;
+    final type = event['type'] as String?;
+    if (type == null) return;
     for (var listener in _listeners) {
       listener.onScreenEvent(type);
     }


### PR DESCRIPTION
for some reason, the type in `ScreenRetriever._handleScreenEvent()` can be null. just added a quick null check

exception details:
```
type 'Null' is not a subtype of type 'String' in type cast => _TypeError
=> #0      ScreenRetriever._handleScreenEvent (package:screen_retriever/src/screen_retriever.dart:15:33)
```